### PR TITLE
[CYB-177] Fix the name of the script to run the parser ui used during installation in cloudera manager.

### DIFF
--- a/flink-cyber/cyber-csd/src/main/scripts/control.sh
+++ b/flink-cyber/cyber-csd/src/main/scripts/control.sh
@@ -21,9 +21,9 @@ export CYBERSEC_CONF_DIR=${CONF_DIR}/cybersec-conf
 
 case $CMD in
   (start-parser-ui)
-    echo "ParserUI echo $CYBERSEC_BIN/start-parser-ui"
+    echo "ParserUI echo $CYBERSEC_BIN/cs-start-parser-ui"
     get_generic_java_opts
-    exec ${CYBERSEC_BIN}/start-parser-ui start
+    exec ${CYBERSEC_BIN}/cs-start-parser-ui start
     ;;
   (*)
     echo "Don't understand [$CMD]"


### PR DESCRIPTION
* fix script naming