### PR TITLE
Add gzip and zip file support to MessageFileParser

### DIFF
--- a/flink-cyber/parser-chains-flink/src/main/java/com/cloudera/cyber/parser/wrappers/MessageFileParser.java
+++ b/flink-cyber/parser-chains-flink/src/main/java/com/cloudera/cyber/parser/wrappers/MessageFileParser.java
@@ -34,6 +34,7 @@ public class MessageFileParser implements ParserInterface {
     public static final String MESSAGE_SOURCE_FILE_STATUS = "message_file_status";
     public static final String INVALID_PATHS_MESSAGE = "The following allowed paths are invalid: %s";
     public static final String NO_ALLOWED_PATHS_SPECIFIED_FOR_MESSAGE_FILE_PARSER = "Null or empty allowed paths specified for message file parser.";
+    public static final String ZIP_FILE_CONTAINS_NO_ENTRIES_ERROR = "Zip file contains no entries.";
     private final List<String> allowedPaths;
     private final SingleMessageParser singleMessageParser;
 
@@ -172,7 +173,7 @@ public class MessageFileParser implements ParserInterface {
                 ZipInputStream zipIn = new ZipInputStream(inputStream, StandardCharsets.UTF_8);
                 ZipEntry entry = zipIn.getNextEntry();
                 if (entry == null) {
-                    throw new IOException("Zip file contains no entries: " + filePath);
+                    throw new IOException(ZIP_FILE_CONTAINS_NO_ENTRIES_ERROR);
                 }
                 return zipIn;
             }

--- a/flink-cyber/parser-chains-flink/src/main/java/com/cloudera/cyber/parser/wrappers/MessageFileParser.java
+++ b/flink-cyber/parser-chains-flink/src/main/java/com/cloudera/cyber/parser/wrappers/MessageFileParser.java
@@ -14,11 +14,15 @@ import org.apache.flink.core.fs.Path;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipInputStream;
 import java.time.Instant;
 import java.util.*;
+import java.util.zip.ZipEntry;
 
 @Slf4j
 public class MessageFileParser implements ParserInterface {
@@ -95,7 +99,8 @@ public class MessageFileParser implements ParserInterface {
                     if (allowedPaths.stream().anyMatch(fileToParsePathString::startsWith)) {
                         FileSystem fileSystem = fileToParsePath.getFileSystem();
                         try (FSDataInputStream is = fileSystem.open(fileToParsePath)) {
-                            try (BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+                            try (InputStream decompressedStream = createDecompressionStream(is, fileToParsePath.toUri().toString());
+                                 BufferedReader br = new BufferedReader(new InputStreamReader(decompressedStream, StandardCharsets.UTF_8))) {
                                 String line;
                                 int lineNumber = 1;
                                 while ((line = br.readLine()) != null) {
@@ -148,6 +153,30 @@ public class MessageFileParser implements ParserInterface {
                 }
             }
             return fileToParsePath;
+        }
+
+        /**
+         * Creates an input stream that handles decompression for gzip and zip compressed files,
+         * or returns the original stream if the file is not compressed.
+         *
+         * @param inputStream The input stream to decompress if needed
+         * @param filePath The file path (used to determine compression type from extension)
+         * @return A stream that provides decompressed data
+         * @throws IOException If decompression fails
+         */
+        private InputStream createDecompressionStream(InputStream inputStream, String filePath) throws IOException {
+            String pathLower = filePath.toLowerCase();
+            if (pathLower.endsWith(".gz") || pathLower.endsWith(".gzip")) {
+                return new GZIPInputStream(inputStream);
+            } else if (pathLower.endsWith(".zip")) {
+                ZipInputStream zipIn = new ZipInputStream(inputStream, StandardCharsets.UTF_8);
+                ZipEntry entry = zipIn.getNextEntry();
+                if (entry == null) {
+                    throw new IOException("Zip file contains no entries: " + filePath);
+                }
+                return zipIn;
+            }
+            return inputStream;
         }
     private void sendErrorMessage(String source, MessageToParse message, AbstractParserOutput output, String errorText, String fileToParse) {
         Map<String, String> extensions = new HashMap<>();

--- a/flink-cyber/parser-chains-flink/src/test/java/com/cloudera/cyber/parser/wrappers/MessageFileParserTest.java
+++ b/flink-cyber/parser-chains-flink/src/test/java/com/cloudera/cyber/parser/wrappers/MessageFileParserTest.java
@@ -153,17 +153,30 @@ public class MessageFileParserTest {
             gzipOut.write(sampleContent.getBytes(StandardCharsets.UTF_8));
         }
 
-        MessageFileParser parser = createMessageFileParserToTest(Collections.singletonList(testTempDir.toString()));
-        MessageToParse messageToParse = MessageFileParserTestUtil.createMessageToParse(gzipFile.toString());
-        ParserTestUtils.TestParserOutput parserOutput = new ParserTestUtils.TestParserOutput();
-        parser.parse(new ParserChainSource("vpcflow", "netflow"), messageToParse, parserOutput);
+        testCompressedFileParsing(gzipFile);
+    }
+
+    private void testCompressedFileParsing(Path compressedFile) throws IOException, NoSuchAlgorithmException, InvalidKeyException, InvalidParserException {
+        ParserTestUtils.TestParserOutput parserOutput = getFileParserOutput(compressedFile);
 
         // Should successfully parse 2 messages from the gzip file
         assertThat(parserOutput.getOutput().stream()
                 .filter(m -> !MESSAGE_SOURCE_FILE_STATUS.equals(m.getSource()))
                 .count()).isEqualTo(2);
 
-        Files.deleteIfExists(gzipFile);
+        Files.deleteIfExists(compressedFile);
+    }
+
+    private ParserTestUtils.TestParserOutput getFileParserOutput(Path compressedFile) throws IOException, NoSuchAlgorithmException, InvalidKeyException, InvalidParserException {
+        // resolve to real path - MACOS uses links for temp dir
+        compressedFile = compressedFile.toRealPath();
+
+        MessageFileParser parser = createMessageFileParserToTest(Collections.singletonList(compressedFile.getParent().toString()));
+        MessageToParse messageToParse = MessageFileParserTestUtil.createMessageToParse(compressedFile.toString());
+        ParserTestUtils.TestParserOutput parserOutput = new ParserTestUtils.TestParserOutput();
+        parser.parse(new ParserChainSource("vpcflow", "netflow"), messageToParse, parserOutput);
+
+        return parserOutput;
     }
 
     @Test
@@ -179,32 +192,7 @@ public class MessageFileParserTest {
             zipOut.closeEntry();
         }
 
-        MessageFileParser parser = createMessageFileParserToTest(Collections.singletonList(testTempDir.toString()));
-        MessageToParse messageToParse = MessageFileParserTestUtil.createMessageToParse(zipFile.toString());
-        ParserTestUtils.TestParserOutput parserOutput = new ParserTestUtils.TestParserOutput();
-        parser.parse(new ParserChainSource("vpcflow", "netflow"), messageToParse, parserOutput);
-
-        // Should successfully parse 2 messages from the zip file
-        assertThat(parserOutput.getOutput().stream()
-                .filter(m -> !MESSAGE_SOURCE_FILE_STATUS.equals(m.getSource()))
-                .count()).isEqualTo(2);
-
-        Files.deleteIfExists(zipFile);
-    }
-
-    @Test
-    public void testParsePlainFile() throws IOException, NoSuchAlgorithmException, InvalidKeyException, InvalidParserException {
-        // Test that plain (uncompressed) files still work
-        MessageFileParser parser = createMessageFileParserToTest(Collections.singletonList(MessageFileParserTestUtil.getValidMessageFileAllowedPath()));
-
-        MessageToParse messageToParse = MessageFileParserTestUtil.createMessageToParse("message_file/vpc_flow_samples.txt");
-        ParserTestUtils.TestParserOutput parserOutput = new ParserTestUtils.TestParserOutput();
-        parser.parse(new ParserChainSource("vpcflow", "netflow"), messageToParse, parserOutput);
-
-        // Should successfully parse 2 messages (same as testSuccessful)
-        assertThat(parserOutput.getOutput().stream()
-                .filter(m -> !MESSAGE_SOURCE_FILE_STATUS.equals(m.getSource()))
-                .count()).isEqualTo(2);
+        testCompressedFileParsing(zipFile);
     }
 
     @Test
@@ -218,16 +206,33 @@ public class MessageFileParserTest {
             gzipOut.write(sampleContent.getBytes(StandardCharsets.UTF_8));
         }
 
-        MessageFileParser parser = createMessageFileParserToTest(Collections.singletonList(testTempDir.toString()));
-        MessageToParse messageToParse = MessageFileParserTestUtil.createMessageToParse(gzipFile.toString());
-        ParserTestUtils.TestParserOutput parserOutput = new ParserTestUtils.TestParserOutput();
-        parser.parse(new ParserChainSource("vpcflow", "netflow"), messageToParse, parserOutput);
-
-        // Should successfully parse 2 messages from the .gzip file
-        assertThat(parserOutput.getOutput().stream()
-                .filter(m -> !MESSAGE_SOURCE_FILE_STATUS.equals(m.getSource()))
-                .count()).isEqualTo(2);
-
-        Files.deleteIfExists(gzipFile);
+        testCompressedFileParsing(gzipFile);
     }
+
+    @Test
+    public void testSendingInNonCompressedFileWithGzipExtension() throws IOException, NoSuchAlgorithmException, InvalidKeyException, InvalidParserException {
+        testBadCompressedFileExtension(".gzip", "java.util.zip.ZipException with message Not in GZIP format");
+    }
+
+    @Test
+    public void testSendingInNonCompressedFileWithZipExtension() throws IOException, NoSuchAlgorithmException, InvalidKeyException, InvalidParserException {
+        testBadCompressedFileExtension(".zip", "java.io.IOException with message ".concat(ZIP_FILE_CONTAINS_NO_ENTRIES_ERROR));
+    }
+
+    private void testBadCompressedFileExtension(String extension, String expectedErrorMessage) throws IOException, NoSuchAlgorithmException, InvalidKeyException, InvalidParserException {
+        // Create a temporary file with compressed extension but the file is not actually compressed
+        String sampleContent = "10.0.0.1 10.0.0.2 443 443 6 120 120 162 OK Ingress\n" +
+                "10.0.0.3 10.0.0.4 80 80 6 60 60 162 OK Egress";
+        Path tempDirPath = testTempDir.toPath();
+        Path uncompressedFileWithZippedExtension = Files.createTempFile(tempDirPath, "file_with_bad_ext", extension);
+        try (FileOutputStream uncompressedFile = new FileOutputStream(uncompressedFileWithZippedExtension.toFile())) {
+            uncompressedFile.write(sampleContent.getBytes(StandardCharsets.UTF_8));
+        }
+
+        ParserTestUtils.TestParserOutput parserOutput = getFileParserOutput(uncompressedFileWithZippedExtension);
+        assertThat(parserOutput.getOutput()).hasSize(1);
+        assertThat(parserOutput.getOutput().get(0).getDataQualityMessages().get(0).getMessage()).isEqualTo(expectedErrorMessage);
+
+    }
+
 }

--- a/flink-cyber/parser-chains-flink/src/test/java/com/cloudera/cyber/parser/wrappers/MessageFileParserTest.java
+++ b/flink-cyber/parser-chains-flink/src/test/java/com/cloudera/cyber/parser/wrappers/MessageFileParserTest.java
@@ -25,6 +25,7 @@ import java.util.zip.ZipOutputStream;
 
 import static com.cloudera.cyber.parser.wrappers.MessageFileParser.*;
 import static com.cloudera.cyber.parser.wrappers.SingleMessageParser.EMPTY_SIGNATURE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MessageFileParserTest {
@@ -146,7 +147,8 @@ public class MessageFileParserTest {
         // Create a temporary gzipped file
         String sampleContent = "10.0.0.1 10.0.0.2 443 443 6 120 120 162 OK Ingress\n" +
                         "10.0.0.3 10.0.0.4 80 80 6 60 60 162 OK Egress";
-        Path gzipFile = Files.createTempFile(testTempDir, "test_data", ".gz");
+        Path tempDirPath = testTempDir.toPath();
+        Path gzipFile = Files.createTempFile(tempDirPath, "test_data", ".gz");
         try (GZIPOutputStream gzipOut = new GZIPOutputStream(new FileOutputStream(gzipFile.toFile()))) {
             gzipOut.write(sampleContent.getBytes(StandardCharsets.UTF_8));
         }
@@ -169,7 +171,8 @@ public class MessageFileParserTest {
         // Create a temporary zip file
         String sampleContent = "10.0.0.1 10.0.0.2 443 443 6 120 120 162 OK Ingress\n" +
                         "10.0.0.3 10.0.0.4 80 80 6 60 60 162 OK Egress";
-        Path zipFile = Files.createTempFile(testTempDir, "test_data", ".zip");
+        Path tempDirPath = testTempDir.toPath();
+        Path zipFile = Files.createTempFile(tempDirPath, "test_data", ".zip");
         try (ZipOutputStream zipOut = new ZipOutputStream(new FileOutputStream(zipFile.toFile()))) {
             zipOut.putNextEntry(new ZipEntry("data.txt"));
             zipOut.write(sampleContent.getBytes(StandardCharsets.UTF_8));
@@ -209,7 +212,8 @@ public class MessageFileParserTest {
         // Create a temporary file with .gzip extension (different from .gz)
         String sampleContent = "10.0.0.1 10.0.0.2 443 443 6 120 120 162 OK Ingress\n" +
                         "10.0.0.3 10.0.0.4 80 80 6 60 60 162 OK Egress";
-        Path gzipFile = Files.createTempFile(testTempDir, "test_data", ".gzip");
+        Path tempDirPath = testTempDir.toPath();
+        Path gzipFile = Files.createTempFile(tempDirPath, "test_data", ".gzip");
         try (GZIPOutputStream gzipOut = new GZIPOutputStream(new FileOutputStream(gzipFile.toFile()))) {
             gzipOut.write(sampleContent.getBytes(StandardCharsets.UTF_8));
         }

--- a/flink-cyber/parser-chains-flink/src/test/java/com/cloudera/cyber/parser/wrappers/MessageFileParserTest.java
+++ b/flink-cyber/parser-chains-flink/src/test/java/com/cloudera/cyber/parser/wrappers/MessageFileParserTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -17,6 +19,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static com.cloudera.cyber.parser.wrappers.MessageFileParser.*;
 import static com.cloudera.cyber.parser.wrappers.SingleMessageParser.EMPTY_SIGNATURE;
@@ -134,5 +139,91 @@ public class MessageFileParserTest {
         parser.parse(parserChainSource, messageToParse, parserOutput);
 
         MessageFileParserTestUtil.verifyErrorMessage(parserOutput, messageToParse, filePath, expectedSource, expectedErrorMessage, EMPTY_SIGNATURE);
+    }
+
+    @Test
+    public void testParseGzippedFile() throws IOException, NoSuchAlgorithmException, InvalidKeyException, InvalidParserException {
+        // Create a temporary gzipped file
+        String sampleContent = "10.0.0.1 10.0.0.2 443 443 6 120 120 162 OK Ingress\n" +
+                        "10.0.0.3 10.0.0.4 80 80 6 60 60 162 OK Egress";
+        Path gzipFile = Files.createTempFile(testTempDir, "test_data", ".gz");
+        try (GZIPOutputStream gzipOut = new GZIPOutputStream(new FileOutputStream(gzipFile.toFile()))) {
+            gzipOut.write(sampleContent.getBytes(StandardCharsets.UTF_8));
+        }
+
+        MessageFileParser parser = createMessageFileParserToTest(Collections.singletonList(testTempDir.toString()));
+        MessageToParse messageToParse = MessageFileParserTestUtil.createMessageToParse(gzipFile.toString());
+        ParserTestUtils.TestParserOutput parserOutput = new ParserTestUtils.TestParserOutput();
+        parser.parse(new ParserChainSource("vpcflow", "netflow"), messageToParse, parserOutput);
+
+        // Should successfully parse 2 messages from the gzip file
+        assertThat(parserOutput.getOutput().stream()
+                .filter(m -> !MESSAGE_SOURCE_FILE_STATUS.equals(m.getSource()))
+                .count()).isEqualTo(2);
+
+        Files.deleteIfExists(gzipFile);
+    }
+
+    @Test
+    public void testParseZippedFile() throws IOException, NoSuchAlgorithmException, InvalidKeyException, InvalidParserException {
+        // Create a temporary zip file
+        String sampleContent = "10.0.0.1 10.0.0.2 443 443 6 120 120 162 OK Ingress\n" +
+                        "10.0.0.3 10.0.0.4 80 80 6 60 60 162 OK Egress";
+        Path zipFile = Files.createTempFile(testTempDir, "test_data", ".zip");
+        try (ZipOutputStream zipOut = new ZipOutputStream(new FileOutputStream(zipFile.toFile()))) {
+            zipOut.putNextEntry(new ZipEntry("data.txt"));
+            zipOut.write(sampleContent.getBytes(StandardCharsets.UTF_8));
+            zipOut.closeEntry();
+        }
+
+        MessageFileParser parser = createMessageFileParserToTest(Collections.singletonList(testTempDir.toString()));
+        MessageToParse messageToParse = MessageFileParserTestUtil.createMessageToParse(zipFile.toString());
+        ParserTestUtils.TestParserOutput parserOutput = new ParserTestUtils.TestParserOutput();
+        parser.parse(new ParserChainSource("vpcflow", "netflow"), messageToParse, parserOutput);
+
+        // Should successfully parse 2 messages from the zip file
+        assertThat(parserOutput.getOutput().stream()
+                .filter(m -> !MESSAGE_SOURCE_FILE_STATUS.equals(m.getSource()))
+                .count()).isEqualTo(2);
+
+        Files.deleteIfExists(zipFile);
+    }
+
+    @Test
+    public void testParsePlainFile() throws IOException, NoSuchAlgorithmException, InvalidKeyException, InvalidParserException {
+        // Test that plain (uncompressed) files still work
+        MessageFileParser parser = createMessageFileParserToTest(Collections.singletonList(MessageFileParserTestUtil.getValidMessageFileAllowedPath()));
+
+        MessageToParse messageToParse = MessageFileParserTestUtil.createMessageToParse("message_file/vpc_flow_samples.txt");
+        ParserTestUtils.TestParserOutput parserOutput = new ParserTestUtils.TestParserOutput();
+        parser.parse(new ParserChainSource("vpcflow", "netflow"), messageToParse, parserOutput);
+
+        // Should successfully parse 2 messages (same as testSuccessful)
+        assertThat(parserOutput.getOutput().stream()
+                .filter(m -> !MESSAGE_SOURCE_FILE_STATUS.equals(m.getSource()))
+                .count()).isEqualTo(2);
+    }
+
+    @Test
+    public void testParseGzipExtensionFile() throws IOException, NoSuchAlgorithmException, InvalidKeyException, InvalidParserException {
+        // Create a temporary file with .gzip extension (different from .gz)
+        String sampleContent = "10.0.0.1 10.0.0.2 443 443 6 120 120 162 OK Ingress\n" +
+                        "10.0.0.3 10.0.0.4 80 80 6 60 60 162 OK Egress";
+        Path gzipFile = Files.createTempFile(testTempDir, "test_data", ".gzip");
+        try (GZIPOutputStream gzipOut = new GZIPOutputStream(new FileOutputStream(gzipFile.toFile()))) {
+            gzipOut.write(sampleContent.getBytes(StandardCharsets.UTF_8));
+        }
+
+        MessageFileParser parser = createMessageFileParserToTest(Collections.singletonList(testTempDir.toString()));
+        MessageToParse messageToParse = MessageFileParserTestUtil.createMessageToParse(gzipFile.toString());
+        ParserTestUtils.TestParserOutput parserOutput = new ParserTestUtils.TestParserOutput();
+        parser.parse(new ParserChainSource("vpcflow", "netflow"), messageToParse, parserOutput);
+
+        // Should successfully parse 2 messages from the .gzip file
+        assertThat(parserOutput.getOutput().stream()
+                .filter(m -> !MESSAGE_SOURCE_FILE_STATUS.equals(m.getSource()))
+                .count()).isEqualTo(2);
+
+        Files.deleteIfExists(gzipFile);
     }
 }


### PR DESCRIPTION
## Summary
This PR adds support for reading compressed message files in the MessageFileParser.

### Changes
- Added automatic decompression for `.gz`, `.gzip`, and `.zip` files
- Files are decompressed on-the-fly based on their extension
- Uncompressed files continue to work as before

### Technical Details
- Uses Java's built-in `java.util.zip` package (GZIPInputStream, ZipInputStream)
- Compression type is detected from file extension
- Minimal, safe changes to the existing parsing logic

### Testing
- Added unit tests for:
  - `.gz` files (testParseGzippedFile)
  - `.zip` files (testParseZippedFile)
  - `.gzip` files (testParseGzipExtensionFile)
  - Plain files (testParsePlainFile - regression test)

This PR was created by an AI assistant (OpenHands) on behalf of the user.

@carolynduby can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3004ed78-4d7d-4adb-a080-d0d4c7c21a1d)